### PR TITLE
DTSPO-18899 - added zone redundant flag for eventhub namespace

### DIFF
--- a/eventhub.tf
+++ b/eventhub.tf
@@ -4,6 +4,7 @@ resource "azurerm_eventhub_namespace" "eventhub-namespace" {
   resource_group_name = local.resource_group
   sku                 = var.eventhub_ns_sku
   tags                = var.common_tags
+  zone_redundant      = var.zone_redundant
 }
 
 resource "azurerm_eventhub" "eventhub" {
@@ -19,7 +20,7 @@ resource "azurerm_eventhub_namespace_authorization_rule" "eventhub-sender" {
   name                = "dlrm-eventhub-namespace-sender"
   namespace_name      = azurerm_eventhub_namespace.eventhub-namespace.name
   resource_group_name = local.resource_group
-  listen = false
-  send   = true
-  manage = false
+  listen              = false
+  send                = true
+  manage              = false
 }

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -71,3 +71,9 @@ variable "additional_kv_access_policies" {
   }))
   default = {}
 }
+
+variable "zone_redundant" {
+  type        = bool
+  default     = false
+  description = "Allows you to make eventhub namespace zone reduntdant"
+}


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-18899


### Change description

Added zone_redundant flag to avoid resources being redeployed here..

https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=656369&view=logs&j=0243f9ef-7e9f-5287-1bb4-0f98db49322f&t=7abc8707-84ef-5e6b-af44-c7ab78ce6cd2&l=493

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
